### PR TITLE
Replace unsupported sudo with become keyword.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   register: opt_kitware
 
 - name: Ensure installation directory
-  sudo: True
+  become: yes
   file: state=directory mode=0755 dest={{cmake_dest_dir}}
   when: opt_kitware.stat.exists == False
 
@@ -22,11 +22,10 @@
 
 - name: Install CMake
   unarchive: copy=no src={{cmake_temp}} dest={{cmake_dest_dir}}
-  sudo: True
+  become: yes
   when: (bin_cmake.stat.exists == False) and  (cmake_downloaded | success)
 
 - name: Add CMake to the PATH
-  sudo: no
   lineinfile:
     dest: "{{ cmake_rcfile }}"
     line: export PATH={{ cmake_install_dir }}/bin:$PATH


### PR DESCRIPTION
Hello,

As of ansible 2.9 the 'sudo' keyword is unsupported. This patch will make the role compatible with current and previous ansible versions.